### PR TITLE
mark seo-analytics as bot

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,422 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# Set the language for reviews by using the corresponding ISO language code.
+language: "de-DE"
+
+# Set the tone of reviews and chat. Example: 'You must use talk like Mr. T. I pity the fool who doesn't!'
+# default: ''
+tone_instructions: ''
+
+# Enable early-access features.
+# default: false
+early_access: false
+
+# Enable free tier features for users not on a paid plan.
+# default: true
+enable_free_tier: true
+
+reviews:
+  # Set the profile for reviews. `Assertive` profile yields more feedback, that may be considered nitpick.
+  # default: chill
+  profile: chill
+
+  # Approve the review once CodeRabbit's comments are resolved. Note: In GitLab, all discussions must be resolved.
+  # default: false
+  request_changes_workflow: false
+
+  # Generate a high level summary of the changes in the PR/MR description.
+  # default: true
+  high_level_summary: true
+
+  # Placeholder in the PR/MR description that gets replaced with the high level summary.
+  # default: '@coderabbitai summary'
+  high_level_summary_placeholder: '@coderabbitai summary'
+
+  # Include the high level summary in the walkthrough comment.
+  # default: false
+  high_level_summary_in_walkthrough: false
+
+  # Add this keyword in the PR/MR title to auto-generate the title.
+  # default: '@coderabbitai'
+  auto_title_placeholder: '@coderabbitai'
+
+  # Auto Title Instructions | Custom instructions for auto-generating the PR/MR title.
+  # default: ''
+  auto_title_instructions: ''
+
+  # Post review details on each review. Additionally, post a review status when a review is skipped in certain cases.
+  # default: true
+  review_status: true
+
+  # Set the commit status to 'pending' when the review is in progress and 'success' when it is complete.
+  # default: true
+  commit_status: true
+
+  # Set the commit status to 'failure' when the PR cannot be reviewed by CodeRabbit for any reason.
+  # default: false
+  fail_commit_status: false
+
+  # Generate walkthrough in a markdown collapsible section.
+  # default: false
+  collapse_walkthrough: false
+
+  # Generate a summary of the changed files in the walkthrough.
+  # default: true
+  changed_files_summary: true
+
+  # Generate sequence diagrams in the walkthrough.
+  # default: true
+  sequence_diagrams: true
+
+  # Generate an assessment of how well the changes address the linked issues in the walkthrough.
+  # default: true
+  assess_linked_issues: true
+
+  # Include possibly related issues in the walkthrough.
+  # default: true
+  related_issues: true
+
+  # Related PRs | Include possibly related pull requests in the walkthrough.
+  # default: true
+  related_prs: true
+
+  # Suggest labels based on the changes in the pull request in the walkthrough.
+  # default: true
+  suggested_labels: true
+
+  # Automatically apply the suggested labels to the PR/MR.
+  # default: false
+  auto_apply_labels: false
+
+  # Suggest reviewers based on the changes in the pull request in the walkthrough.
+  # default: true
+  suggested_reviewers: true
+
+  # Automatically assign suggested reviewers to the pull request
+  # default: false
+  auto_assign_reviewers: false
+
+  # Generate a poem in the walkthrough comment.
+  # default: true
+  poem: false
+
+  # Labeling Instructions | Provide guidelines for suggesting labels for the PR/MR. When specific labels or instructions are provided, only those labels are considered, though previous examples are still used to inform the suggestions. If no such labels are provided, suggestions are based solely on previous PR/MRs.
+  # default: []
+  labeling_instructions: [ ]
+
+  # Abort the in-progress review if the pull request is closed or merged.
+  # default: true
+  abort_on_close: true
+
+  # Disable caching of code and dependencies. This will force CodeRabbit to download the code and dependencies fresh from the repository each time.
+  # default: false
+  disable_cache: false
+
+  # Settings related to reviews.
+  auto_review:
+    # Automatic Review | Automatic code review
+    # default: true
+    enabled: true
+    # Automatic Incremental Review | Automatic incremental code review on each push
+    # default: true
+    auto_incremental_review: true
+    # default: 5
+    auto_pause_after_reviewed_commits: 0
+    # Ignore reviewing if the title of the pull request contains any of these keywords (case-insensitive).
+    # default: []
+    ignore_title_keywords: []
+    # Restrict automatic reviews to only those pull requests that match one of the specified labels.
+    # default: []
+    labels: []
+    # Review draft PRs/MRs.
+    # default: false
+    drafts: false
+    # Base branches (other than the default branch) to review. Accepts regex patterns.
+    # default: []
+    base_branches:
+      - "master"
+
+  finishing_touches:
+    # Docstrings | Options for generating Docstrings for your PRs/MRs.
+    docstrings:
+      # Docstrings | Allow CodeRabbit to generate docstrings for PRs/MRs.
+      # default: true
+      enabled: true
+
+  # Tools that provide additional context to code reviews.
+  tools:
+    # ShellCheck is a static analysis tool that finds bugs in your shell scripts.
+    shellcheck:
+      # Enable ShellCheck | ShellCheck is a static analysis tool that finds bugs in your shell. | Enable ShellCheck integration. | v0.10.0
+      # default: true
+      enabled: true
+
+    # Ruff is a Python linter and code formatter.
+    ruff:
+      # Enable Ruff | Ruff is a Python linter and code formatter. | Enable Ruff integration. | v0.8.2
+      # default: true
+      enabled: false
+
+    # markdownlint-cli2 is a static analysis tool to enforce standards and consistency for Markdown files.
+    markdownlint:
+      # Enable markdownlint | markdownlint-cli2 is a static analysis tool to enforce standards and consistency for Markdown files. | Enable markdownlint integration. | v0.17.2
+      # default: true
+      enabled: true
+
+    # GitHub Checks integration configuration.
+    github-checks:
+      # Enable GitHub Checks | Enable integration, defaults to true | Enable GitHub Checks integration.
+      # default: true
+      enabled: true
+      # Time in milliseconds to wait for all GitHub Checks to conclude. >= 0 and <= 300000
+      # default: 90000
+      timeout_ms: 90000
+
+    # LanguageTool is a style and grammar checker for 30+ languages.
+    languagetool:
+      # Enable LanguageTool | Enable LanguageTool integration.
+      # default: true
+      enabled: true
+      # IDs of rules to be enabled. The rule won't run unless 'level' is set to a level that activates the rule.
+      # default: []
+      enabled_rules: []
+      # IDs of rules to be disabled. Note: EN_UNPAIRED_BRACKETS, and EN_UNPAIRED_QUOTES are always disabled.
+      # default: []
+      disabled_rules: []
+      # IDs of categories to be enabled.
+      # default: []
+      enabled_categories: []
+      # IDs of categories to be disabled. Note: TYPOS, TYPOGRAPHY, and CASING are always disabled.
+      # default: []
+      disabled_categories: []
+      # Only the rules and categories whose IDs are specified with 'enabledRules' or 'enabledCategories' are enabled.
+      # default: false
+      enabled_only: false
+      # If set to `picky`, additional rules will be activated, i.e. rules that you might only find useful when checking formal text.
+      # default: default
+      level: default
+
+    # Biome is a fast formatter, linter, and analyzer for web projects.
+    biome:
+      # Enable Biome | Biome is a fast formatter, linter, and analyzer for web projects. | Enable Biome integration. | v1.9.4
+      # default: true
+      enabled: false
+
+    # Hadolint is a Dockerfile linter.
+    hadolint:
+      # Enable Hadolint | Hadolint is a Dockerfile linter. | Enable Hadolint integration. | v2.12.0
+      # default: true
+      enabled: false
+
+    # SwiftLint integration configuration object.
+    swiftlint:
+      # Enable SwiftLint | SwiftLint is a Swift linter. | Enable SwiftLint integration. | v0.57.0
+      # default: true
+      enabled: false
+      # Optional path to the SwiftLint configuration file relative to the repository. This is useful when the configuration file is named differently than the default '.swiftlint.yml' or '.swiftlint.yaml'.
+    #      config_file:
+
+    # PHPStan is a tool to analyze PHP code.
+    phpstan:
+      # Enable PHPStan | PHPStan requires [config file](https://phpstan.org/config-reference#config-file) in your repository root. Please ensure that this file contains the `paths:` parameter. | v2.0.3
+      # default: true
+      enabled: true
+      # Level | Specify the [rule level](https://phpstan.org/user-guide/rule-levels) to run. This setting is ignored if your configuration file already has a `level:` parameter.
+      # default: default
+      level: default
+
+    # golangci-lint is a fast linters runner for Go.
+    golangci-lint:
+      # Enable golangci-lint | golangci-lint is a fast linters runner for Go. | Enable golangci-lint integration. | v1.64.8
+      # default: true
+      enabled: false
+      # Optional path to the golangci-lint configuration file relative to the repository. Useful when the configuration file is named differently than the default '.golangci.yml', '.golangci.yaml', '.golangci.toml', '.golangci.json'.
+    #      config_file:
+
+    # YAMLlint is a linter for YAML files.
+    yamllint:
+      # Enable YAMLlint | YAMLlint is a linter for YAML files. | Enable YAMLlint integration. | v1.35.1
+      # default: true
+      enabled: true
+
+    # Gitleaks is a secret scanner.
+    gitleaks:
+      # Enable Gitleaks | Gitleaks is a secret scanner. | Enable Gitleaks integration. | v8.21.2
+      # default: true
+      enabled: true
+
+    # Checkov is a static code analysis tool for infrastructure-as-code files.
+    checkov:
+      # Enable Checkov | Checkov is a static code analysis tool for infrastructure-as-code files. | v3.2.334
+      # default: true
+      enabled: false
+
+    # Detekt is a static code analysis tool for Kotlin files.
+    detekt:
+      # Enable detekt | detekt is a static code analysis tool for Kotlin files. | v1.23.7
+      # default: true
+      enabled: false
+      # Optional path to the detekt configuration file relative to the repository.
+    #      config_file:
+
+    # ESLint is a static code analysis tool for JavaScript files.
+    eslint:
+      # Enable ESLint | ESLint is a static code analysis tool for JavaScript files. | v8.45.0
+      # default: true
+      enabled: true
+
+    # RuboCop is a Ruby static code analyzer (a.k.a. linter ) and code formatter.
+    rubocop:
+      # Enable RuboCop | RuboCop is a Ruby static code analyzer (a.k.a. linter ) and code formatter. | v1.73
+      # default: true
+      enabled: false
+
+    # Buf offers linting for Protobuf files.
+    buf:
+      # Enable Buf | Buf offers linting for Protobuf files. | v1.47.2
+      # default: true
+      enabled: false
+
+    # Regal is a linter and language server for Rego.
+    regal:
+      # Enable Regal | Regal is a linter and language server for Rego. | v0.29.2
+      # default: true
+      enabled: false
+
+    # actionlint is a static checker for GitHub Actions workflow files.
+    actionlint:
+      # Enable actionlint | is a static checker for GitHub Actions workflow files. | v1.7.4
+      # default: true
+      enabled: true
+
+    # PMD is an extensible multilanguage static code analyzer. It’s mainly concerned with Java.
+    pmd:
+      # Enable PMD | PMD is an extensible multilanguage static code analyzer. It’s mainly concerned with Java. | v7.8.0
+      # default: true
+      enabled: false
+      # Optional path to the PMD configuration file relative to the repository.
+    #      config_file:
+
+    # Cppcheck is a static code analysis tool for the C and C++ programming languages.
+    cppcheck:
+      # Enable Cppcheck | Cppcheck is a static code analysis tool for the C and C++ programming languages. | v2.10-2
+      # default: true
+      enabled: false
+
+    # Semgrep is a static analysis tool designed to scan code for security vulnerabilities and code quality issues.
+    semgrep:
+      # Enable Semgrep | Semgrep is a static analysis tool designed to scan code for security vulnerabilities and code quality issues. | Enable Semgrep integration. | v1.99.0
+      # default: true
+      enabled: false
+      # Optional path to the Semgrep configuration file relative to the repository.
+    #      config_file:
+
+    # CircleCI tool is a static checker for CircleCI config files.
+    circleci:
+      # Enable CircleCI | CircleCI tool is a static checker for CircleCI config files. | v0.1.31151
+      # default: true
+      enabled: false
+
+    # SQLFluff is an open source, dialect-flexible and configurable SQL linter.
+    sqlfluff:
+      # Enable SQLFluff | SQLFluff is an open source, dialect-flexible and configurable SQL linter. | v3.3.0
+      # default: true
+      enabled: false
+
+    # Configuration for Prisma Schema linting to ensure schema file quality
+    prismaLint:
+      # Enable Prisma Schema linting | Prisma Schema linting helps maintain consistent and error-free schema files | v0.10.0
+      # default: true
+      enabled: false
+
+    # OXC is a JavaScript/TypeScript linter written in Rust.
+    oxc:
+      # Enable OXC | OXC is a JavaScript/TypeScript linter written in Rust. | v0.16.5
+      # default: true
+      enabled: true
+
+    # Configuration for Shopify Theme Check to ensure theme quality and best practices
+    shopifyThemeCheck:
+      # Enable Shopify Theme Check | A linter for Shopify themes that helps you follow Shopify theme & Liquid best practices | cli 3.77.1 | theme 3.58.2
+      # default: true
+      enabled: false
+
+  # Specify file patterns to include or exclude in a review using glob patterns (e.g., !dist/**, src/**). These patterns also apply to 'git sparse-checkout', including specified patterns and ignoring excluded ones (starting with '!') when cloning the repository.
+  # default: []
+  path_filters:
+    - "!build/**"
+
+  # Path Instructions | Provide specific additional guidelines for code review based on file paths.
+  # default: []
+  path_instructions:
+    - path: "**/*.{html,php}"
+      instructions: |
+        "Perform a detailed review of the provided code with following key aspects in mind:
+          - Review the HTML and PHP code to ensure it is well-structured and adheres to best practices.
+          - Ensure the code follows coding standards and is well-documented.
+          - Confirm the code is secure and free from vulnerabilities.
+          - Optimize the code for performance, removing any unnecessary elements.
+          - Validate comments for accuracy, currency, and adherence to coding standards."
+
+chat:
+  # Enable the bot to reply automatically without requiring the user to tag it.
+  auto_reply: true
+  integrations:
+    jira:
+      # Jira | Enable the Jira integration for opening issues, etc. 'auto' disables the integration for public repositories. `auto`, `enabled`, `disabled`
+      # default: auto
+      usage: disabled
+    linear:
+      # Linear | Enable the Linear integration for opening issues, etc. 'auto' disables the integration for public repositories. `auto`, `enabled`, `disabled`
+      # default: auto
+      usage: disabled
+
+knowledge_base:
+  # Opt Out | Disable all knowledge base features that require data retention. If you opt out after opting in, all of your existing knowledge base data will be removed from the system.
+  # default: false
+  opt_out: false
+
+  web_search:
+    # Web Search | Enable the web search integration.
+    # default: true
+    enabled: true
+
+  learnings:
+    # Learnings | Specify the scope of learnings to use for the knowledge base. 'local' uses the repository's learnings, 'global' uses the organization's learnings, and 'auto' uses repository's learnings for public repositories and organization's learnings for private repositories.
+    # default: auto
+    scope: auto
+
+  issues:
+    # Issues | Specify the scope of git platform (GitHub/GitLab) issues to use for the knowledge base. 'local' uses the repository's issues, 'global' uses the organization's issues, and 'auto' uses repository's issues for public repositories and organization's issues for private repositories.
+    # default: auto
+    scope: auto
+
+  jira:
+    # Jira | Enable the Jira knowledge base integration. 'auto' disables the integration for public repositories. `auto`, `enabled`, `disabled`
+    # default: auto
+    usage: disabled
+    # Jira Project Keys | Specify the Jira project keys to use for the knowledge base.
+    # default: []
+    project_keys: []
+
+  linear:
+    # Linear | Enable the Linear knowledge base integration. 'auto' disables the integration for public repositories. `auto`, `enabled`, `disabled`
+    # default: auto
+    usage: disabled
+    # Linear Team Keys | Specify the Linear team keys (identifiers) to use for the knowledge base. E.g. 'ENG'
+    # default: []
+    team_keys: []
+
+  pull_requests:
+    # Pull Requests | Specify the scope of pull requests to use for the knowledge base. 'local' uses the repository's pull requests, 'global' uses the organization's pull requests, and 'auto' uses repository's pull requests for public repositories and organization's pull requests for private repositories.
+    # default: auto
+    scope: auto
+
+code_generation:
+  # Settings related to the generation of docstrings.
+  docstrings:
+    # Set the language for docstrings by using the corresponding ISO language code.
+    language: de-DE
+    # Path Instructions | Provide additional guidelines for docstring generation based on file paths.
+    # default: []
+    path_instructions: []

--- a/.gitattributes
+++ b/.gitattributes
@@ -65,46 +65,31 @@
 *.zip            -text binary
 
 # files/folders to ignore
-/.*                       export-ignore
-.github/CODEOWNERS        export-ignore text eol=lf
-.browserslistrc           export-ignore text eol=lf
-.codeclimate.yml          export-ignore text eol=lf
-.editorconfig             export-ignore text eol=lf
-.eslintignore             export-ignore text eol=lf
-.eslintrc.json            export-ignore text eol=lf
-.gitattributes            export-ignore text eol=lf
-.gitignore                export-ignore text eol=lf
-.jshintrc                 export-ignore text eol=lf
-.markdown-link-check.json export-ignore text eol=lf
-.markdownlint.yaml        export-ignore text eol=lf
-.mega-linter.yml          export-ignore text eol=lf
-.noai                     export-ignore text eol=lf
-.npmrc                    export-ignore text eol=lf
-.php-cs-fixer.php         export-ignore text eol=lf
-.phplint.yml              export-ignore text eol=lf
-.prettierignore           export-ignore text eol=lf
-.prettierrc.json          export-ignore text eol=lf
-.stylelintrc.json         export-ignore text eol=lf
-.yamllint.yml             export-ignore text eol=lf
-codecov.yml               export-ignore text eol=lf
-infection.json            export-ignore text eol=lf
-infection.json5           export-ignore text eol=lf
-phpcs.xml                 export-ignore text eol=lf
-phpmd.ruleset.xml         export-ignore text eol=lf
-phpstan.neon              export-ignore text eol=lf
-phpunit.xml               export-ignore text eol=lf
-phpunit-integration.xml   export-ignore text eol=lf
-postcss.config.cjs        export-ignore text eol=lf
-postcss.config.json       export-ignore text eol=lf
-psalm.xml                 export-ignore text eol=lf
-rector.php                export-ignore text eol=lf
-tsconfig.json             export-ignore text eol=lf
-tsconfig.node.json        export-ignore text eol=lf
-vite.config.ts            export-ignore text eol=lf
-/cache                    export-ignore
-/examples                 export-ignore
-/resources                export-ignore
-/test                     export-ignore
-/tests                    export-ignore
-/tools                    export-ignore
-/.github                  export-ignore
+/.*                              export-ignore
+.github/CODEOWNERS               export-ignore text eol=lf
+.codeclimate.yml                 export-ignore text eol=lf
+.coderabbit.yaml                 export-ignore text eol=lf
+.editorconfig                    export-ignore text eol=lf
+.gitattributes                   export-ignore text eol=lf
+.gitignore                       export-ignore text eol=lf
+.markdown-link-check.json        export-ignore text eol=lf
+.markdownlint.yaml               export-ignore text eol=lf
+.mega-linter.yml                 export-ignore text eol=lf
+.php-cs-fixer.php                export-ignore text eol=lf
+.phplint.yml                     export-ignore text eol=lf
+.yamllint.yml                    export-ignore text eol=lf
+codecov.yml                      export-ignore text eol=lf
+composer-dependency-analyser.php export-ignore text eol=lf
+infection.json5                  export-ignore text eol=lf
+phpcs.xml                        export-ignore text eol=lf
+phpstan.neon                     export-ignore text eol=lf
+phpunit.xml                      export-ignore text eol=lf
+phpunit-integration.xml          export-ignore text eol=lf
+rector.php                       export-ignore text eol=lf
+/cache                           export-ignore
+/examples                        export-ignore
+/resources                       export-ignore
+/test                            export-ignore
+/tests                           export-ignore
+/tools                           export-ignore
+/.github                         export-ignore

--- a/src/Type.php
+++ b/src/Type.php
@@ -166,7 +166,7 @@ enum Type: string implements TypeInterface
     public function isBot(): bool
     {
         return match ($this) {
-            self::Bot, self::BotSyndicationReader, self::BotTrancoder, self::Crawler, self::DownloadManager, self::LinkChecker, self::SearchBot, self::SearchEngine, self::SecurityChecker, self::SecuritySearchBot, self::ServiceAgent, self::SiteMonitor, self::SocialMediaAgent, self::Tool, self::UseragentAnonymizer => true,
+            self::Bot, self::BotSyndicationReader, self::BotTrancoder, self::Crawler, self::DownloadManager, self::LinkChecker, self::SearchBot, self::SearchEngine, self::SecurityChecker, self::SecuritySearchBot, self::SeoAnalytics, self::ServiceAgent, self::SiteMonitor, self::SocialMediaAgent, self::Tool, self::UseragentAnonymizer => true,
             default => false,
         };
     }

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -224,7 +224,7 @@ final class TypeTest extends TestCase
             [
                 'type' => 'seo-analytics',
                 'name' => 'SEO & Analytics',
-                'isBot' => false,
+                'isBot' => true,
                 'isSyndicationReader' => false,
                 'isTranscoder' => false,
             ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * SEO-Analytics wird nun korrekt als Bot-Datenverkehr klassifiziert und in den Besucherstatistiken entsprechend berücksichtigt.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mimmi20/ua-browser-type/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->